### PR TITLE
Support Rebus 6

### DIFF
--- a/Rebus.Ninject.Tests/Rebus.Ninject.Tests.csproj
+++ b/Rebus.Ninject.Tests/Rebus.Ninject.Tests.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.Ninject.Tests</RootNamespace>
     <AssemblyName>Rebus.Ninject.Tests</AssemblyName>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -31,11 +31,14 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <DefineConstants>NETSTANDARD1_6</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
+    <DefineConstants>NETSTANDARD2_0</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.Ninject\Rebus.Ninject.csproj" />
     <PackageReference Include="ninject" Version="4.0.0-beta-0134" />
-    <PackageReference Include="nunit" Version="3.7.1" />
-    <PackageReference Include="rebus" Version="4.0.0" />
-    <PackageReference Include="rebus.tests.contracts" Version="4.0.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="rebus" Version="6.0.0" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Ninject/NinjectContainerAdapter.cs
+++ b/Rebus.Ninject/NinjectContainerAdapter.cs
@@ -37,7 +37,7 @@ namespace Rebus.Ninject
         {
             var handlerInstances = GetAllHandlerInstances<TMessage>();
 
-            transactionContext.OnDisposed(() =>
+            transactionContext.OnDisposed(_ =>
             {
                 foreach (var disposableInstance in handlerInstances.OfType<IDisposable>())
                 {

--- a/Rebus.Ninject/Rebus.Ninject.csproj
+++ b/Rebus.Ninject/Rebus.Ninject.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rebus.Ninject</RootNamespace>
     <AssemblyName>Rebus.Ninject</AssemblyName>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>mookid8000</Authors>
     <PackageLicenseUrl>https://raw.githubusercontent.com/rebus-org/Rebus/master/LICENSE.md</PackageLicenseUrl>
@@ -43,13 +43,16 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <DefineConstants>NETSTANDARD1_6</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>NETSTANDARD2_0</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ninject" Version="4.0.0-beta-0134" />
-    <PackageReference Include="rebus" Version="4.0.0" />
+    <PackageReference Include="rebus" Version="6.0.0" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
When upgrading our Rebus version, we started getting the exception: 
System.MissingMethodException: Method not found: 'Void Rebus.Transport.ITransactionContext.OnDisposed(System.Action)'.
   at Rebus.Ninject.NinjectContainerAdapter.<GetHandlers>d__2`1.MoveNext()

To fix this I just made the same update that I saw being done in the Castle Windsor container. Also I removed .net standard 1.6 as target in favor of 2.0 as Rebus 6 also doesn't support 1.6. 

Unfortunately it seems that Ninject still doesn't support .net core, so this exercise may be academic at this point. 

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
